### PR TITLE
Upgrade to 2.0.0-rc-1, also updated all other dependencies, resolves ratpack/example-ratpack-gradle-java-app#7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
-        classpath 'io.ratpack:ratpack-gradle:1.0.0',
-                  'com.github.jengelman.gradle.plugins:shadow:1.2.1'
+        classpath 'io.ratpack:ratpack-gradle:2.0.0-rc-1',
+                  'gradle.plugin.com.github.johnrengelman:shadow:7.1.2'
     }
 }
 
@@ -18,15 +19,15 @@ apply plugin: "io.ratpack.ratpack-java"
 apply plugin: "com.github.johnrengelman.shadow"
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    testCompile 'junit:junit:4.11'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
 
     // This is a Guice ratpack app
-    compile ratpack.dependency("guice")
-    runtime 'org.slf4j:slf4j-simple:1.7.10'
+    implementation  ratpack.dependency("guice")
+    runtimeOnly 'org.slf4j:slf4j-simple:1.7.36'
 }
 
 // The “ratpack” plugin is IDEA aware.
@@ -50,5 +51,9 @@ idea {
 
 //some CI config
 apply from: file("gradle/ci.gradle")
+
+test {
+    useJUnitPlatform()
+}
 
 mainClassName = "ratpack.example.java.MyApp"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Sat Nov 09 15:05:56 GMT 2013
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip

--- a/src/main/java/ratpack/example/java/LoggingHandler.java
+++ b/src/main/java/ratpack/example/java/LoggingHandler.java
@@ -1,7 +1,7 @@
 package ratpack.example.java;
 
-import ratpack.handling.Context;
-import ratpack.handling.Handler;
+import ratpack.core.handling.Context;
+import ratpack.core.handling.Handler;
 
 /**
  * An example of a handler implicitly set up by a module

--- a/src/main/java/ratpack/example/java/MyApp.java
+++ b/src/main/java/ratpack/example/java/MyApp.java
@@ -1,10 +1,9 @@
 package ratpack.example.java;
 
+import ratpack.core.handling.Chain;
+import ratpack.core.server.BaseDir;
+import ratpack.core.server.RatpackServer;
 import ratpack.guice.Guice;
-import ratpack.handling.Chain;
-import ratpack.server.BaseDir;
-import ratpack.server.RatpackServer;
-
 import java.util.Map;
 
 public class MyApp {

--- a/src/main/java/ratpack/example/java/MyHandler.java
+++ b/src/main/java/ratpack/example/java/MyHandler.java
@@ -1,7 +1,7 @@
 package ratpack.example.java;
 
-import ratpack.handling.Context;
-import ratpack.handling.Handler;
+import ratpack.core.handling.Context;
+import ratpack.core.handling.Handler;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;

--- a/src/main/java/ratpack/example/java/MyModule.java
+++ b/src/main/java/ratpack/example/java/MyModule.java
@@ -2,7 +2,7 @@ package ratpack.example.java;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
-import ratpack.handling.HandlerDecorator;
+import ratpack.core.handling.HandlerDecorator;
 
 /**
  * An example Guice module.
@@ -11,7 +11,7 @@ public class MyModule extends AbstractModule {
 
   /**
    * Adds a service impl to the application, and registers a decorator so that all requests are logged.
-   * Registered implementations of {@link ratpack.handling.HandlerDecorator} are able to decorate the application handler.
+   * Registered implementations of {@link ratpack.core.handling.HandlerDecorator} are able to decorate the application handler.
    *
    * @see MyHandler
    */

--- a/src/test/java/ratpack/example/java/SiteTest.java
+++ b/src/test/java/ratpack/example/java/SiteTest.java
@@ -1,21 +1,18 @@
 package ratpack.example.java;
 
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import ratpack.test.MainClassApplicationUnderTest;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@RunWith(JUnit4.class)
 public class SiteTest {
 
   String lineSeparator = System.getProperty("line.separator");
 
   MainClassApplicationUnderTest aut = new MainClassApplicationUnderTest(MyApp.class);
 
-  @After
+  @AfterEach
   public void tearDown() {
     aut.close();
   }


### PR DESCRIPTION
- Removed obsolete Repo jcenter
- Added Repo gradlePluginPortal, as this was required by the newer version of the Shadow Plugin
- useJUnitPlatform() is required for JUnit 5